### PR TITLE
Update to dart 1.9.3

### DIFF
--- a/Dart SDK/chocolateyInstall.ps1
+++ b/Dart SDK/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $packageName = 'dart-sdk'
 
 # https://www.dartlang.org/tools/download_archive/
-$url = 'https://storage.googleapis.com/dart-archive/channels/stable/release/42828/sdk/dartsdk-windows-ia32-release.zip'
-$url64 = 'https://storage.googleapis.com/dart-archive/channels/stable/release/42828/sdk/dartsdk-windows-x64-release.zip'
+$url = 'https://storage.googleapis.com/dart-archive/channels/stable/release/45104/sdk/dartsdk-windows-ia32-release.zip'
+$url64 = 'https://storage.googleapis.com/dart-archive/channels/stable/release/45104/sdk/dartsdk-windows-x64-release.zip'
 
 $unzipDir = Get-BinRoot # NOTE: We're not adding dart-sdk to the end, as that's already in the zip file.
 $installDir = Join-Path $unzipDir "dart-sdk"

--- a/Dart SDK/dart-sdk.nuspec
+++ b/Dart SDK/dart-sdk.nuspec
@@ -7,7 +7,7 @@ The Dart SDK has the libraries and command-line tools that you need to develop D
 
 Dart is a cohesive, scalable platform for building apps that run on the web (where you can use Polymer) or on servers (such as with Google Cloud Platform). Use the Dart language, libraries, and tools to write anything from simple scripts to full-featured apps.
     </description>
-    <version>1.8.5.0</version>
+    <version>1.9.3</version>
     <authors>Google</authors>
     <iconUrl>https://cdn.rawgit.com/dart-lang/www.dartlang.org/master/src/site/logos/dart-logo.png</iconUrl>
   </metadata>

--- a/Dartium/chocolateyInstall.ps1
+++ b/Dartium/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $packageName = 'dartium'
 
 # https://www.dartlang.org/tools/download_archive/
-$url = 'https://storage.googleapis.com/dart-archive/channels/stable/release/42828/dartium/dartium-windows-ia32-release.zip'
+$url = 'https://storage.googleapis.com/dart-archive/channels/stable/release/45104/dartium/dartium-windows-ia32-release.zip'
 
 $binRoot = Get-BinRoot
 $installDir = Join-Path $binRoot "dartium"

--- a/Dartium/dartium.nuspec
+++ b/Dartium/dartium.nuspec
@@ -7,7 +7,7 @@ Dartium is a special build of Chromium that includes the Dart VM. Using Dartium 
 
 Dart is a cohesive, scalable platform for building apps that run on the web (where you can use Polymer) or on servers (such as with Google Cloud Platform). Use the Dart language, libraries, and tools to write anything from simple scripts to full-featured apps.
     </description>
-    <version>1.8.5.0</version>
+    <version>1.9.3</version>
     <authors>Google</authors>
     <iconUrl>https://cdn.rawgit.com/dart-lang/www.dartlang.org/master/src/site/logos/dart-logo.png</iconUrl>
   </metadata>


### PR DESCRIPTION
@daftspaniel @DanTup I need a Windows Dart SDK 1.9 version for my appveyor build.
So I try to help by update links for Dart 1.9.3.